### PR TITLE
cals-1278: use correct org reference in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>capraconsulting/renovate-config:aggressive"]
+  "extends": ["github>capralifecycle/renovate-config:aggressive"]
 }


### PR DESCRIPTION
Update org-reference in Renovate config to avoid relying on GitHub redirects.

CALS-1278